### PR TITLE
go docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Whether you need a basic Discord bot in a *pinch* or want to spice up your serve
   — Get info about a YouTuber's last upload
 - [timestamp](/lib/timestamp/)
   — Generate timestamps for Discord
+  - [unixtime](/lib/timestamp/unixtime/)
+    — Get unix time from given time variables
 
 ### Fun
 

--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ Whether you need a basic Discord bot in a *pinch* or want to spice up your serve
 - [dice](/lib/dice/)
   — For most of your dice rolling needs
   - [roll](/lib/dice/roll/)
-  — For the rest of your dice rolling needs
+    — For the rest of your dice rolling needs

--- a/lib/crabtalk/README.md
+++ b/lib/crabtalk/README.md
@@ -1,6 +1,6 @@
 # crabot/crabtalk
 
-Translate English [^1] to crab.
+Translate English to crab.
 
 ## How it Works
 
@@ -21,9 +21,3 @@ Here is an example of crabtalk.
 .... . .-.. .-.. --- / .-- --- .-. .-.. -..
 clickclickclickclick click clickclackclickclick clickclackclickclick clackclackclack / clickclackclack clackclackclack clickclackclick clickclackclickclick clackclickclick
 ```
-
----
-
-[^1]: More languages planned!
-  See issue [#foo](https://github.com/ArkhamCookie/crabot/issues/) <!-- issue not created yet -->
-  This means we will also translate [non-Latin extensions/alphabets](https://wikipedia.org/wiki/Morse_code_for_non-Latin_alphabets).

--- a/lib/crabtalk/crabtalk.go
+++ b/lib/crabtalk/crabtalk.go
@@ -26,7 +26,7 @@ func convert(text string) string {
 	return text
 }
 
-// Get the *text* in "crab"
+// Get the `text` in "crab"
 func Get(text string) (string, error) {
 	// Confirm that text is given
 	if text == "" {

--- a/lib/crabtalk/doc.go
+++ b/lib/crabtalk/doc.go
@@ -1,0 +1,2 @@
+// Translate English to crab.
+package crabtalk

--- a/lib/dice/diceTypes.go
+++ b/lib/dice/diceTypes.go
@@ -4,7 +4,7 @@ import (
 	"crabot/dice/roll"
 )
 
-// D2 rolls a D2 (1-2)
+// D2 rolls a D2 (1-2) `count` amount of times.
 func D2(count int) (result int) {
 	for range count {
 		result += roll.Roll(2)
@@ -12,7 +12,7 @@ func D2(count int) (result int) {
 	return result
 }
 
-// D4 rolls a D4 (1-4)
+// D4 rolls a D4 (1-4) `count` amount of times.
 func D4(count int) (result int) {
 	for range count {
 		result += roll.Roll(4)
@@ -20,7 +20,7 @@ func D4(count int) (result int) {
 	return result
 }
 
-// D6 rolls a D6 (1-6)
+// D6 rolls a D6 (1-6) `count` amount of times.
 func D6(count int) (result int) {
 	for range count {
 		result += roll.Roll(6)
@@ -28,7 +28,7 @@ func D6(count int) (result int) {
 	return result
 }
 
-// D8 rolls a D8 (1-8)
+// D8 rolls a D8 (1-8) `count` amount of times.
 func D8(count int) (result int) {
 	for range count {
 		result += roll.Roll(8)
@@ -36,7 +36,7 @@ func D8(count int) (result int) {
 	return result
 }
 
-// D10 rolls a D10 (1-10)
+// D10 rolls a D10 (1-10) `count` amount of times.
 func D10(count int) (result int) {
 	for range count {
 		result += roll.Roll(10)
@@ -44,7 +44,7 @@ func D10(count int) (result int) {
 	return result
 }
 
-// D12 rolls a D12 (1-12)
+// D12 rolls a D12 (1-12) `count` amount of times.
 func D12(count int) (result int) {
 	for range count {
 		result += roll.Roll(12)
@@ -52,7 +52,7 @@ func D12(count int) (result int) {
 	return result
 }
 
-// D20 rolls a D20 (1-20)
+// D20 rolls a D20 (1-20) `count` amount of times.
 func D20(count int) (result int) {
 	for range count {
 		result += roll.Roll(20)
@@ -60,7 +60,9 @@ func D20(count int) (result int) {
 	return result
 }
 
-// D00 rolls a D00 (percentile dice)
+// D00 rolls a D00 (percentile dice) `count` amount of times.
+//
+// Results are stored in `[]int`.
 func D00(count int) []int {
 	var result int
 	// Create the results array

--- a/lib/dice/doc.go
+++ b/lib/dice/doc.go
@@ -1,0 +1,4 @@
+// Package dice provides functions for commmon rolling for dice and similar functions.
+//
+// Includes rolling common types of dice, flipping a coin, and calling a coin in the air.
+package dice

--- a/lib/dice/roll/doc.go
+++ b/lib/dice/roll/doc.go
@@ -1,0 +1,7 @@
+// A package that rolls any type of dice.
+//
+// It uses the [math/rand] package.
+// It should **not** be used for security-sensitive work as the seeds are predictable.
+//
+// [math/rand]: https://pkg.go.dev/math/rand
+package roll

--- a/lib/dice/roll/doc.go
+++ b/lib/dice/roll/doc.go
@@ -1,4 +1,4 @@
-// A package that rolls any type of dice.
+// Package roll rolls any type of dice.
 //
 // It uses the [math/rand] package.
 // It should **not** be used for security-sensitive work as the seeds are predictable.

--- a/lib/dice/roll/roll.go
+++ b/lib/dice/roll/roll.go
@@ -2,7 +2,9 @@ package roll
 
 import "math/rand"
 
-// Roll *dice* and return the roll.
+// Roll returns a "roll" of a given `dice`.
+//
+// Always returns greater than or equal to 1.
 func Roll(dice int) int {
 	// Add 1 so it 1-int rather than 0-int
 	return rand.Intn(dice) + 1

--- a/lib/lastupload/README.md
+++ b/lib/lastupload/README.md
@@ -1,0 +1,3 @@
+# crabot/lastupload
+
+Fetch the last upload of a YouTuber.

--- a/lib/lastupload/README.md
+++ b/lib/lastupload/README.md
@@ -1,3 +1,59 @@
 # crabot/lastupload
 
 Fetch the last upload of a YouTuber.
+
+## Examples
+
+### Get a Channels' ID
+
+```golang
+package main
+
+import (
+  "fmt"
+
+  "github.com/arkhamcookie/crabot/lastupload"
+)
+
+func main() {
+  YOUTUBE_KEY := "" // Insert your API key
+
+  // Fetch channelID
+  channelID, err := lastupload.GetChannelID("spiritvoices", YOUTUBE_KEY)
+  if err != nil {
+    fmt.Printf("[ERROR]: %v\n", err)
+  }
+
+  fmt.Println(channelID) // UCi_0J4Zm1qwiYVSGRsA0_Bg
+}
+```
+
+### Get a Channel's Last Upload Time
+
+```golang
+package main
+
+import (
+  "fmt"
+
+  "github.com/arkhamcookie/crabot/lastupload"
+)
+
+func main() {
+  YOUTUBE_KEY := "" // Insert your API key
+
+  // Get the last upload data
+  uploadData, err := lastupload.GetData("spiritvoices", YOUTUBE_KEY)
+  if err != nil {
+    fmt.Printf("[ERROR]: %v\n", err)
+  }
+
+  // Fetch channelID
+  date, err := lastupload.GetDate(uploadData, YOUTUBE_KEY)
+  if err != nil {
+    fmt.Printf("[ERROR]: %v\n", err)
+  }
+
+  fmt.Println(date)
+}
+```

--- a/lib/lastupload/doc.go
+++ b/lib/lastupload/doc.go
@@ -1,0 +1,4 @@
+// Package lastupload revolves around functions that help get the last upload of a YouTuber.
+//
+// All functions requre a Google API key that works with YouTube Data API v3.
+package lastupload

--- a/lib/lastupload/get.go
+++ b/lib/lastupload/get.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Get the data related to latest upload based on YouTube username.
-func Get(username, YOUTUBE_KEY string) ([]LastUploadResults, error) {
+func GetData(username, YOUTUBE_KEY string) ([]LastUploadResults, error) {
 	channelID, err := GetChannelID(username, YOUTUBE_KEY)
 	if err != nil {
 		return nil, err

--- a/lib/lastupload/get.go
+++ b/lib/lastupload/get.go
@@ -5,6 +5,7 @@ import (
 	"time"
 )
 
+// Get the data related to latest upload based on YouTube username.
 func Get(username, YOUTUBE_KEY string) ([]LastUploadResults, error) {
 	channelID, err := GetChannelID(username, YOUTUBE_KEY)
 	if err != nil {
@@ -24,6 +25,9 @@ func Get(username, YOUTUBE_KEY string) ([]LastUploadResults, error) {
 	return lastUploadData, nil
 }
 
+// Get the date of the lastest upload based on LastUploadResults.
+//
+// LastUploadResults can be gotten by running the `lastupload.Get` functiion.
 func GetDate(lastUploadResults []LastUploadResults) (time.Time, error) {
 	// Get last upload date from lastUploadResults
 	lastUpload := lastUploadResults[0].Snippet.PublishedAt.String()

--- a/lib/lastupload/getChannelID.go
+++ b/lib/lastupload/getChannelID.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 )
 
+// Get a channel's ID based on the given YouTube username.
 func GetChannelID(username, YOUTUBE_KEY string) (string, error) {
 	response, err := http.Get("https://www.googleapis.com/youtube/v3/search?part=snippet&q=" + username + "&type=channel&key=" + YOUTUBE_KEY)
 	if err != nil {

--- a/lib/lastupload/getLastUpload.go
+++ b/lib/lastupload/getLastUpload.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 )
 
+// Get the data related to latest upload based on upload playlist ID.
 func GetLastUploadData(upload_playlist_id, YOUTUBE_KEY string) ([]LastUploadResults, error) {
 	response, err := http.Get("https://www.googleapis.com/youtube/v3/playlistItems?part=snippet&playlistId=" + upload_playlist_id + "&maxResults=1&key=" + YOUTUBE_KEY)
 	if err != nil {

--- a/lib/lastupload/getUploadsPlaylistID.go
+++ b/lib/lastupload/getUploadsPlaylistID.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 )
 
+// Get a channel upload playlist from a channel ID.
 func GetUploadsPlaylistID(channelID, YOUTUBE_KEY string) (string, error) {
 	response, err := http.Get("https://www.googleapis.com/youtube/v3/channels?part=contentDetails&id=" + channelID + "&key=" + YOUTUBE_KEY)
 	if err != nil {

--- a/lib/lastupload/get_test.go
+++ b/lib/lastupload/get_test.go
@@ -7,13 +7,13 @@ import (
 	"crabot/lastupload"
 )
 
-func TestGet(t *testing.T) {
+func TestGetData(t *testing.T) {
 	YOUTUBE_KEY, err := env.GetEnvValue("YOUTUBE_KEY", "./../../.env")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_, err = lastupload.Get("spiritvoices", YOUTUBE_KEY)
+	_, err = lastupload.GetData("spiritvoices", YOUTUBE_KEY)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -25,7 +25,7 @@ func TestGetDate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	lastUploadData, err := lastupload.Get("spiritvoices", YOUTUBE_KEY)
+	lastUploadData, err := lastupload.GetData("spiritvoices", YOUTUBE_KEY)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lib/timestamp/README.md
+++ b/lib/timestamp/README.md
@@ -1,0 +1,3 @@
+# crabot/timestamps
+
+Create Discord timestamps based on given time.

--- a/lib/timestamp/currentTimestamp.go
+++ b/lib/timestamp/currentTimestamp.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Get current time's unix time as a string
+// Get current time's unix time as a string.
 func currentTime() string {
 	timeStart := time.Now().Unix()
 	convertedTime := strconv.FormatInt(timeStart, 10)

--- a/lib/timestamp/currentTimestamp.go
+++ b/lib/timestamp/currentTimestamp.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Get current time's unix timestamp as a string
 func currentTime() string {
 	timeStart := time.Now().Unix()
 	convertedTime := strconv.FormatInt(timeStart, 10)
@@ -13,42 +14,49 @@ func currentTime() string {
 	return convertedTime
 }
 
+// Get timestamp for current time in short date format.
 func CurrentShortDate() string {
 	now := currentTime()
 
 	return fmt.Sprintf("<t:%v:d>", now)
 }
 
+// Get timestamp for current time in long date format.
 func CurrentLongDate() string {
 	now := currentTime()
 
 	return fmt.Sprintf("<t:%v:D>", now)
 }
 
+// Get timestamp for current time in short time format.
 func CurrentShortTime() string {
 	now := currentTime()
 
 	return fmt.Sprintf("<t:%v:t>", now)
 }
 
+// Get timestamp for current time in long time format.
 func CurrentLongTime() string {
 	now := currentTime()
 
 	return fmt.Sprintf("<t:%v:T>", now)
 }
 
+// Get timestamp for current time in short full format.
 func CurrentShortFull() string {
 	now := currentTime()
 
 	return fmt.Sprintf("<t:%v:f>", now)
 }
 
+// Get timestamp for current time in long full format.
 func CurrentLongFull() string {
 	now := currentTime()
 
 	return fmt.Sprintf("<t:%v:F>", now)
 }
 
+// Get timestamp for current time in relative time format.
 func CurrentRelativeTime() string {
 	currentTime := time.Now().Unix()
 	convertedTime := strconv.FormatInt(currentTime, 10)
@@ -56,6 +64,7 @@ func CurrentRelativeTime() string {
 	return fmt.Sprintf("<t:%v:R>", convertedTime)
 }
 
+// Get unix timestamp of current time.
 func CurrentUnixTimestamp() string {
 	return currentTime()
 }

--- a/lib/timestamp/currentTimestamp.go
+++ b/lib/timestamp/currentTimestamp.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-// Get current time's unix timestamp as a string
+// Get current time's unix time as a string
 func currentTime() string {
 	timeStart := time.Now().Unix()
 	convertedTime := strconv.FormatInt(timeStart, 10)

--- a/lib/timestamp/doc.go
+++ b/lib/timestamp/doc.go
@@ -1,0 +1,2 @@
+// Package allows you to generate Discord timestamps from given time.
+package timestamp

--- a/lib/timestamp/timestamp.go
+++ b/lib/timestamp/timestamp.go
@@ -7,6 +7,7 @@ import (
 	"crabot/unixtime"
 )
 
+// Get timestamp from given time in short date format.
 func ShortDate(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {
@@ -18,6 +19,7 @@ func ShortDate(year, month, day, hour, minute, second int, timezone string) (str
 	return timestamp, nil
 }
 
+// Get timestamp from given time in long date format.
 func LongDate(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {
@@ -29,6 +31,7 @@ func LongDate(year, month, day, hour, minute, second int, timezone string) (stri
 	return timestamp, nil
 }
 
+// Get timestamp from given time in short time format.
 func ShortTime(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {
@@ -40,6 +43,7 @@ func ShortTime(year, month, day, hour, minute, second int, timezone string) (str
 	return timestamp, nil
 }
 
+// Get timestamp from given time in long time format.
 func LongTime(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {
@@ -51,6 +55,7 @@ func LongTime(year, month, day, hour, minute, second int, timezone string) (stri
 	return timestamp, nil
 }
 
+// Get timestamp from given time in short full format.
 func ShortFull(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {
@@ -62,6 +67,7 @@ func ShortFull(year, month, day, hour, minute, second int, timezone string) (str
 	return timestamp, nil
 }
 
+// Get timestamp from given time in long full format.
 func LongFull(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {
@@ -73,6 +79,7 @@ func LongFull(year, month, day, hour, minute, second int, timezone string) (stri
 	return timestamp, nil
 }
 
+// Get timestamp from given time in relative time format.
 func RelativeTime(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {
@@ -84,6 +91,7 @@ func RelativeTime(year, month, day, hour, minute, second int, timezone string) (
 	return timestamp, nil
 }
 
+// Get unix time from given time as string
 func Unix(year, month, day, hour, minute, second int, timezone string) (string, error) {
 	givenTime, err := unixtime.UnixTime(year, month, day, hour, minute, second, timezone)
 	if err != nil {

--- a/lib/timestamp/unixTimestamp.go
+++ b/lib/timestamp/unixTimestamp.go
@@ -4,30 +4,37 @@ import (
 	"fmt"
 )
 
+// Get timestamp from unix timestamp in short date format
 func UnixShortDate(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:d>", unixTime)
 }
 
+// Get timestamp from unix timestamp in long date format
 func UnixLongDate(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:D>", unixTime)
 }
 
+// Get timestamp from unix timestamp in short time format
 func UnixShortTime(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:t>", unixTime)
 }
 
+// Get timestamp from unix timestamp in long time format
 func UnixLongTime(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:T>", unixTime)
 }
 
+// Get timestamp from unix timestamp in short full format
 func UnixShortFull(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:f>", unixTime)
 }
 
+// Get timestamp from unix timestamp in long full format
 func UnixLongFull(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:F>", unixTime)
 }
 
+// Get timestamp from unix timestamp in relative time format
 func UnixRelativeTime(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:R>", unixTime)
 }

--- a/lib/timestamp/unixTimestamp.go
+++ b/lib/timestamp/unixTimestamp.go
@@ -4,37 +4,37 @@ import (
 	"fmt"
 )
 
-// Get timestamp from unix timestamp in short date format
+// Get timestamp from unix timestamp in short date format.
 func UnixShortDate(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:d>", unixTime)
 }
 
-// Get timestamp from unix timestamp in long date format
+// Get timestamp from unix timestamp in long date format.
 func UnixLongDate(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:D>", unixTime)
 }
 
-// Get timestamp from unix timestamp in short time format
+// Get timestamp from unix timestamp in short time format.
 func UnixShortTime(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:t>", unixTime)
 }
 
-// Get timestamp from unix timestamp in long time format
+// Get timestamp from unix timestamp in long time format.
 func UnixLongTime(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:T>", unixTime)
 }
 
-// Get timestamp from unix timestamp in short full format
+// Get timestamp from unix timestamp in short full format.
 func UnixShortFull(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:f>", unixTime)
 }
 
-// Get timestamp from unix timestamp in long full format
+// Get timestamp from unix timestamp in long full format.
 func UnixLongFull(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:F>", unixTime)
 }
 
-// Get timestamp from unix timestamp in relative time format
+// Get timestamp from unix timestamp in relative time format.
 func UnixRelativeTime(unixTime int64) string {
 	return fmt.Sprintf("<t:%v:R>", unixTime)
 }

--- a/lib/timestamp/unixtime/README.md
+++ b/lib/timestamp/unixtime/README.md
@@ -1,0 +1,24 @@
+# crabot/timestamp/unixtime
+
+Convert given time variables to unix time.
+
+## Examples
+
+### Basic Usage
+
+```golang
+package main
+
+import (
+  "fmt"
+
+  "github.com/arkhamcookie/crabot/timestamp/unixtime"
+)
+
+func main() {
+  // Get unix time from given variables
+  unixTime, _ := unixtime.UnixTime(2025, 12, 12, 12, 12, 00, "UTC")
+
+  fmt.Println(unixTime) // "1765541532"
+}
+```

--- a/lib/timestamp/unixtime/doc.go
+++ b/lib/timestamp/unixtime/doc.go
@@ -1,0 +1,2 @@
+// Package returns unix time from given variables.
+package unixtime

--- a/main.go
+++ b/main.go
@@ -371,7 +371,7 @@ var (
 				log.Printf("[ERROR]: %v\n", err)
 			}
 
-			lastUploadData, err := lastupload.Get(username, YOUTUBE_KEY)
+			lastUploadData, err := lastupload.GetData(username, YOUTUBE_KEY)
 			if err != nil {
 				fetechedCorrectly = false
 				log.Printf("[ERROR]: %v\n", err)


### PR DESCRIPTION
- **style: remove unneeded newline**
- **fix: use int64 for unix timestamps**
- **docs: add package docs to `crabot/dice/roll`**
- **docs: improve formatting of go doc comments**
- **docs: improve doc comments in `diceTypes.go`**
- **docs: match style in go docs comment section**
- **docs: add doc.go for dice pkg**
- **docs: match var style in other doc comments**
- **docs: add doc.go to crabtalk pkg**
- **docs: remove mention of translating other langs as not planned anymore**
- **docs: add basic README to lastupload**
- **docs: add `doc.go` for lastupload pkg**
- **docs: add go doc comments to lastupload funcs**
- **feat: improve name to Get func to GetData (more fitting)**
- **docs: add examples to lastupload README**
- **docs: add doc comments for `currentTimestamps.go`**
- **docs: correct wording about unix time**
- **docs: add doc comments for `unixTimestamps.go`**
- **docs: add missing periods**
- **docs: add doc comments to `timestamp.go`**
- **docs: add `doc.go` to timestamps pkg**
- **docs: basic README for timestamps**
- **docs: add README to timestamp/unixtime**
- **docs: add doc.go to unixtime**
- **docs: add unixtime to main README**
- **docs: fix indent of roll**
